### PR TITLE
Fixes pagesize param was retrieved instead of pageSize

### DIFF
--- a/lib/search-index/index.js
+++ b/lib/search-index/index.js
@@ -423,8 +423,8 @@ function getSearchResults (q, tq, i, docSet, idf, indexKeys, callback) {
   var totalIndexedFields = indexMetaDataGlobal['totalIndexedFields'];
   var availableFacets = indexMetaDataGlobal['availableFacets'];
   var thisQueryTerm = indexKeys[i].startKey.split('~')[1];
-  var offset = parseInt(q['offset']);
-  var pageSize = parseInt(q['pagesize']);
+  var offset = ~~parseInt(q['offset']);
+  var pageSize = ~~parseInt(q['pageSize']);
   var weight = {};
   if (q['weight']) {
     weight = q['weight'];


### PR DESCRIPTION
Also, forces casting `offset` and `pageSize` parameters to integers.

This fixes a problem preventing results (`hits`) to be sent in the search response object. 
