### PR TITLE
Convert integers to strings before using substring

### DIFF
--- a/lib/search-index/index.js
+++ b/lib/search-index/index.js
@@ -217,7 +217,7 @@ function indexDoc(docID, doc, facets, indexMetaDataGlobal, callback) {
     if( Object.prototype.toString.call(doc[fieldKey]) === '[object Array]' ) {
       value['fields'][fieldKey] = doc[fieldKey];
     } else {
-      value['fields'][fieldKey] = doc[fieldKey].substring(0, maxStringFieldLength);
+      value['fields'][fieldKey] = doc[fieldKey].toString().substring(0, maxStringFieldLength);
     }
   }
 


### PR DESCRIPTION
When a field value is an integer, substring fails and crashes the process.
A call to `toString()` will convert the integer to a string, and let the substring pass.
