### PR TITLE
Add logSilent option to suppress logs

### DIFF
--- a/lib/search-index.js
+++ b/lib/search-index.js
@@ -25,28 +25,35 @@ var indexes = null, indexesMultiply = null;
 
 var defaults = {
   indexPath: 'si',
-  logLevel: 'info'
+  logLevel: 'info',
+  logSilent: false
 };
 
 var SearchIndex = module.exports = function (options) {
   var logLevel = 'info';
   var indexPath = 'si';
+  var logSilent = false;
+
   if (options) {
-    if (options.logLevel) 
+    if (options.logLevel)
       logLevel = options.logLevel;
-    if (options.indexPath) 
+    if (options.indexPath)
       indexPath = options.indexPath;
+    if (options.logSilent)
+      logSilent = options.logSilent;
   }
   indexes = level(indexPath, {valueEncoding: 'json'}),
   indexesMultiply = levelMultiply(indexes);
 
   searchIndexLogger = new (winston.Logger)({
     transports: [
-      new (winston.transports.Console)({ level: logLevel }),
-      //    new (winston.transports.File)({ filename: 'somefile.log' })
+      new (winston.transports.Console)({
+        level: logLevel,
+        silent: logSilent
+      })
     ]
   });
-  
+
   calibrater.getTotalDocs(indexes, function(totalDocs) {
     searcher.setTotalDocs(totalDocs);
   });
@@ -161,5 +168,3 @@ SearchIndex.calibrate = function(callback) {
     callback(msg);
   });
 };
-
-

--- a/test/spec/6config-spec.js
+++ b/test/spec/6config-spec.js
@@ -17,4 +17,16 @@ describe('configuration', function () {
       return fs.existsSync('si2');
     }, 5000);
   });
+
+  it('should accept logSilent in configuration', function () {
+     var si;
+
+     runs(function () {
+         si = require('../../lib/search-index.js')({ logSilent: true });
+     });
+
+     waitsFor(function() {
+         return searchIndexLogger.transports.console.silent;
+     }, 5000);
+  });
 });


### PR DESCRIPTION
This is a simple modification to allow a new option `logSilent` to suppress log messages.

How to use:

```
var si = require('search-index')({ logSilent: true });
// si will not log anything from now on
```

Since the logger is global, there is no way to use different `logSilent` values when using multiple search-index instances (is this really supported anyway?). I strongly recommend modifying this lib to make it object-friendly, so that we can use multiple search indexes in the same process!
