### PR TITLE
The symbols `_` and `countDocuments` were leaking.

### DIFF
--- a/lib/indexing/calibrater.js
+++ b/lib/indexing/calibrater.js
@@ -87,7 +87,7 @@ exports.incrementallyCalibrate = function (indexes, tf, callback) {
 }
 
 
-countDocuments = function (indexes, callback) {
+var countDocuments = function (indexes, callback) {
   var tally = 0;
   indexes.createReadStream({
     start: 'DOCUMENT~',

--- a/lib/search-index.js
+++ b/lib/search-index.js
@@ -10,7 +10,7 @@ var SearchIndex = module.exports = function SearchIndex(options) {
   //------------libs
   this.level = require('levelup');
   this.levelMultiply = require('level-multiply');
-  _ = require('lodash');
+  var _ = require('lodash');
   this.defaults = {
     indexPath: 'si',
     logLevel: 'warn'

--- a/test/spec/6config-spec.js
+++ b/test/spec/6config-spec.js
@@ -20,6 +20,15 @@ describe('configuration', function () {
     }, 5000);
   });
 
+  it('does not leak variables', function () {
+
+    runs(function() {
+      expect(typeof countDocuments).toEqual('undefined');
+      expect(typeof _).toEqual('undefined');
+    });
+
+  });
+
 //add in some bunyanny tests here
 
 
@@ -30,7 +39,7 @@ describe('configuration', function () {
     runs(function () {
       si = require('../../')({ logSilent: true });
     });
-    
+
     waitsFor(function() {
       return si.searchIndexLogger.transports.console.silent;
     }, 5000);


### PR DESCRIPTION
Added a little `var` action to keep them out of the global namespace. Wrote a test that fails if they're leaking.