### PR TITLE
Transactional deleteBatch

### DIFF
--- a/lib/indexing/deleter.js
+++ b/lib/indexing/deleter.js
@@ -1,125 +1,74 @@
 //deletes all references to a document from the search index
 
-var async = require('async');
 var skeleton = require('log-skeleton');
+var H = require('highland');
+var transaction = require('level-transactions');
 
 module.exports = function (options) {
   var log = skeleton((options) ? options.log : undefined);
   var deleter = {};
 
-  deleter.deleteBatch = function (batch, index, mainCallback) {
-    batch = batch.sort();
-    var delBatchDeleteDocument = [];
-    var delBatchDocument = [];
+  deleter.deleteBatch = function (batch, index, callback) {
+    var tx = transaction(index);
+
     var recalibrateBatchRI = {};
     var recalibrateBatchTF = {};
-    for (var i = 0; i < batch.length; i++)
-      delBatchDocument.push({type:'del', key: 'DOCUMENT~' + batch[i] + '~'});
     log.info('deleting ' + batch);
-    async.map(batch, function (item, callback) {
-      var deleteKeys = [];
-      index.createReadStream({gte: 'DELETE-DOCUMENT~' + item + '~',
-                              lte: 'DELETE-DOCUMENT~' + item + '~~'})
-        .on('data', function (data) {
-          delBatchDeleteDocument.push({type:'del', key: data.key});
-          deleteKeys.push({key: data.key, value: data.value});
-          for (var i = 0; i < data.value.length; i++) {
-            var tfKey = 'TF~' + data.value[i];
-            if (!recalibrateBatchTF[tfKey]) recalibrateBatchTF[tfKey] = [];
-            recalibrateBatchTF[tfKey].push(item);
 
-            var riKey = 'RI~' + data.value[i];
-            if (!recalibrateBatchRI[riKey]) recalibrateBatchRI[riKey] = [];
-            recalibrateBatchRI[riKey].push(item);
-          }
-        })
-        .on('error', function (err) {
-          log.warn('Oh my!', err);
-        })
-        .on('end', function () {
-          callback(deleteKeys);
-        });
-    }, function (err) {
-      log.warn('Oh my!', err);
-      async.series([
-        function (callbackx) {
-          index.batch(delBatchDocument, function (err) {
-            if (err) return log.err('Ooops!', err);
-            callbackx();
-          });
-        },
-        function (callbackx) {
-          index.batch(delBatchDeleteDocument, function (err) {
-            if (err) return log.err('Ooops!', err);
-            callbackx();
-          });
-        },
-        function (callbackx) {
-          async.map(
-            Object.keys(recalibrateBatchRI),
-            function (item, callbacky) {
-              index.get(item, function (err, value) {
-                var newVal = value.filter(function (arrValue) {
-                  return (recalibrateBatchRI[item].toString()
-                          .indexOf(arrValue[1].toString()) == -1);
-                });
-                if (newVal.length === 0)
-                  index.del(item, function (err) {
-                    if (err) log.err('Ooops!', err);
-                    callbacky(err);
-                  });
-                else
-                  index.put(item, newVal, function (err) {
-                    if (err) log.err('Ooops!', err);
-                    callbacky(err);
-                  });
-              });
-            },
-            function (err) {
-              if (err) log.err('Ooops!', err);
-              callbackx(err);
-            }
-          );
-        },
-        function (callbackx) {
-          async.map(
-            Object.keys(recalibrateBatchTF),
-            function (item, callbacky) {
-              index.get(item, function (err, value) {
-                var newVal = value.filter(function (arrValue) {
-                  return (recalibrateBatchTF[item].indexOf(arrValue.toString()) == -1);
-                });
-                if (newVal.length === 0)
-                  index.del(item, function (err) {
-                    if (err) log.err('Ooops!', err);
-                    callbacky(err);
-                  });
-                else
-                  index.put(item, newVal, function (err) {
-                    if (err) log.err('Ooops!', err);
-                    callbacky(err);
-                  });
-              });
-            },
-            function (err) {
-              if (err) log.err('Ooops!', err);
-              callbackx(err);
-            }
-          );
-        },
-        function (callbackx) {
-          index.get('search-index.totalDocs', function (err, value) {
-            index.put('search-index.totalDocs',
-                      value - delBatchDocument.length, function (err) {
-                        if (err) log.err('Ooops!', err);
-                        callbackx(err);
-                      });
-          });
-        },
-        function () {
-          mainCallback(null);
+    H(batch)
+    .sort()
+    .map(function(item) {
+      tx.del('DOCUMENT~' + item + '~');
+      var deleteKeys = [];
+
+      return H(index.createReadStream({
+        gte: 'DELETE-DOCUMENT~' + item + '~',
+        lte: 'DELETE-DOCUMENT~' + item + '~~'
+      }))
+      .map(function(data){
+        tx.del(data.key);
+        deleteKeys.push({key: data.key, value: data.value});
+        for (var i = 0; i < data.value.length; i++) {
+          var tfKey = 'TF~' + data.value[i];
+          if (!recalibrateBatchTF[tfKey]) recalibrateBatchTF[tfKey] = [];
+          recalibrateBatchTF[tfKey].push(item);
+
+          var riKey = 'RI~' + data.value[i];
+          if (!recalibrateBatchRI[riKey]) recalibrateBatchRI[riKey] = [];
+          recalibrateBatchRI[riKey].push(item);
         }
-      ]);
+        return data;
+      });
+    })
+    .series()
+    .on('error', function(err){
+      log.err('Ooops!', err);
+      callback(err);
+    })
+    .done(function(){
+      Object.keys(recalibrateBatchRI).forEach(function (item) {
+        tx.get(item, function (err, value) {
+          var newVal = value.filter(function (arrValue) {
+            return (recalibrateBatchRI[item].toString()
+                    .indexOf(arrValue[1].toString()) == -1);
+          });
+          if (newVal.length === 0) tx.del(item);
+          else tx.put(item, newVal);
+        });
+      });
+      Object.keys(recalibrateBatchTF).forEach(function(item){
+        tx.get(item, function (err, value) {
+          var newVal = value.filter(function (arrValue) {
+            return (recalibrateBatchTF[item].indexOf(arrValue.toString()) == -1);
+          });
+          if (newVal.length === 0) tx.del(item);
+          else tx.put(item, newVal);
+        });
+      });
+      tx.get('search-index.totalDocs', function (err, value) {
+        tx.put('search-index.totalDocs', value - batch.length);
+      });
+      tx.commit(callback);
     });
   };
   return deleter;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "highland": "^2.5.1",
     "level-js": "2.1.6",
     "level-multiply": "0.0.1",
+    "level-transactions": "^1.2.0",
     "level-ws": "0.0.0",
     "leveldown": "1.3.0",
     "levelup": "1.2.1",


### PR DESCRIPTION
Added highland stuff for deleteBatch, and uses [level-transactions](https://github.com/cshum/level-transactions), the deleteBatch operation becomes atomic (committed or no write at all).

level-transactions also ensures sequential operations within the transaction, even they are asynchronous. Hence omit the needs of most callback functions