### PR TITLE
Bump bunyan to 1.4.0 to support electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "JSONStream": "0.10.0",
     "async": "0.9.0",
-    "bunyan": "1.3.5",
+    "bunyan": "1.4.0",
     "colors": "1.1.0",
     "highland": "^2.5.1",
     "level-js": "2.1.6",


### PR DESCRIPTION
Version 1.3.5 of bunyan was using an old version of dtrace-provider which was being compiled with an older version of Nan which broke using this package in electron (and maybe even iojs). This bump of bunyan fixes the whole dependency chain which should allow search index to be built and used in electron.