### PR TITLE
Fixed API-reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Find out how to use the `search-index` module here:
 
 ### API reference
 
- * [API reference](https://cdn.rawgit.com/fergiemcdowall/search-index/better_docs/doc/api/module-search-index.html)
+ * [API reference](https://cdn.rawgit.com/fergiemcdowall/search-index/master/doc/api/module-search-index.html)
 
 [license-image]: http://img.shields.io/badge/license-MIT-blue.svg?style=flat
 [license-url]: LICENSE


### PR DESCRIPTION
think it's because the original link pointed to a branch that doesn't exist any more (better-doc)