### PR TITLE
Replace all async.map by .mapLimit

### DIFF
--- a/lib/indexing/deleter.js
+++ b/lib/indexing/deleter.js
@@ -10,7 +10,7 @@ module.exports = function (options) {
 
   deleter.deleteBatch = function (deleteBatch, indexes, callbacky) {
     var numberDocsToDelete = 0;
-    a.map(deleteBatch, function (docID, callback) {
+    a.mapLimit(deleteBatch, 5, function (docID, callback) {
       indexes.get('DELETE-DOCUMENT￮' + docID, function (err, keys) {
         if (err) {
           if (err.name == 'NotFoundError') {
@@ -23,7 +23,7 @@ module.exports = function (options) {
       });
     }, function (err, results) {
       if (!err) {
-        a.map(_(results).flatten().sort().uniq(true).value(),
+        a.mapLimit(_(results).flatten().sort().uniq(true).value(), 5,
               function (key, callback) {
                 indexes.get(key, function (err, value) {
                   var dbInstruction = {type: 'put',

--- a/lib/indexing/indexer.js
+++ b/lib/indexing/indexer.js
@@ -179,8 +179,8 @@ module.exports = function (options) {
           }
           return prev;
         }, []);
-      async.map(
-        dbInstructions,
+      async.eachLimit(
+        dbInstructions, 5,
         function (item, callback) {
           indexes.get(item.key, function (err, val) {
             if (item.key.substring(0, 2) == 'TF') {
@@ -199,12 +199,12 @@ module.exports = function (options) {
               if (val)
                 item.value = +val + +(item.value);
             }
-            return callback(null, item);
+            return callback(null);
           });
         },
-        function (err, mergeDbInstructions) {
+        function (err) {
           //          console.log(JSON.stringify(mergeDbInstructions, null, 2))
-          indexes.batch(mergeDbInstructions, function (err) {
+          indexes.batch(dbInstructions, function (err) {
             if (err) log.warn('Ooops!', err);
             else log.info('batch indexed!');
             return callbacky(null);


### PR DESCRIPTION
Hi, we have been experimenting with using search-index as the new FTS engine for cozy.io, it was doing great with small values and simple index (like filenames search) but was choking with hight memory usage once we tried more values and complex docs & index (searching in all emails of several account, about 30,000 emails with a few kb by email, indexing date & accounts as facets and subject as fieldedSearch).

All in one, it made for batch of 3000 to 10000 leveldb keys (we also need to improve our stemming :-) ).

Using async.map, as it was before means these 10000 keys were leveldb.get in parallel, which caused a crazy memory usage in leveldb side. I replaced all of them by mapLimit, i read somewhere that 5 was the sweet spot for parallel leveldb access (but cant remember the source). 

May be linked to : #225 #223 

It would be nice to add tests / benchmark for this. Unfortunately all my test files are real-life emails which would take times to extract 10000 non-confidential from.

Let me know if you want to change anything.