### PR TITLE
Invoking callback early on error to avoid further, misleading errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,11 @@ module.exports = function (givenOptions, callbacky) {
         require('search-index-searcher')(SearchIndex.options, callback)
       }     
     ], function(err, results){
-      
+      if (err) {
+        callbacky(err);
+        return;
+      }      
+
       const searchIndexAdder = results[0]
       const searchIndexGetter = results[1]
       const searchIndexDeleter = results[2]
@@ -53,7 +57,7 @@ module.exports = function (givenOptions, callbacky) {
       SearchIndex.writeStream = searchIndexReplicator.writeStream
 
       SearchIndex.log = SearchIndex.options.log
-      return callbacky(err, SearchIndex)
+      return callbacky(null, SearchIndex)
     })
   })
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ module.exports = function (givenOptions, callbacky) {
 
     async.series([
       function(callback) {
-        require('search-index-adder')(SearchIndex.options, callback)
+        require('ihenshaw-search-index-adder')(SearchIndex.options, callback)
       },
       function(callback) {
         require('search-index-getter')(SearchIndex.options, callback)
@@ -26,7 +26,7 @@ module.exports = function (givenOptions, callbacky) {
         require('search-index-replicator')(SearchIndex.options, callback)
       },
       function(callback) {
-        require('search-index-searcher')(SearchIndex.options, callback)
+        require('ihenshaw-search-index-searcher')(SearchIndex.options, callback)
       }     
     ], function(err, results){
       if (err) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ihenshaw/search-index",
+  "name": "ihenshaw-search-index",
   "description": "A persistent full text search engine for the browser and Node.js",
   "version": "0.8.8",
   "homepage": "https://github.com/fergiemcdowall/search-index",
@@ -14,12 +14,12 @@
     "levelup": "^1.3.1",
     "lodash.defaults": "^4.0.1",
     "lodash.intersection": "^4.1.2",
-    "search-index-adder": "0.0.22",
+    "ihenshaw-search-index-adder": "0.0.22",
     "search-index-deleter": "0.0.9",
     "search-index-getter": "0.0.7",
     "search-index-matcher": "0.0.8",
     "search-index-replicator": "0.0.6",
-    "search-index-searcher": "0.0.15",
+    "ihenshaw-search-index-searcher": "0.0.15",
     "stopword": "0.0.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "search-index",
+  "name": "@ihenshaw/search-index",
   "description": "A persistent full text search engine for the browser and Node.js",
   "version": "0.8.8",
   "homepage": "https://github.com/fergiemcdowall/search-index",
@@ -74,6 +74,9 @@
       "url": "https://github.com/mewwts"
     }
   ],
+  "publishConfig": {
+    "registry": "http://npm.thehenshaws.net/"
+  },
   "scripts": {
     "empty-sandbox": "rm -rf test/sandbox && mkdir test/sandbox",
     "lint": "standard",

--- a/test/browser/browserify-test-uncompiled.js
+++ b/test/browser/browserify-test-uncompiled.js
@@ -8,7 +8,10 @@ levelup('test/sandbox/simpleIndexing', {
 }, function (err, db) {
   if (err) console.log(err)
   SearchIndex({indexes: db}, function (err, si) { // causes woe in browsers
-    if (err) console.log(err)
+    if (err) {
+      console.log(err);
+      return;
+    }
     si.add(batch, {}, function (err) {
       if (err) console.log(err)
       si.get('4', function (err, doc) {


### PR DESCRIPTION
When attempting to use an indexPath where the directory didn't exist, I was presented with an error that was misleading..

TypeError: Cannot read property 'add' of null

This PR resolves the issue by aborting the attempt to create an index if an error has already occurred.
