### PR TITLE
Handle errors during index init

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ const sw = require('stopword')
 module.exports = function (givenOptions, callbacky) {
   var SearchIndex = {}
   getOptions(givenOptions, function(err, options) {
+    if (err) return callbacky(err)
+
     SearchIndex.options = options
 
     async.series([
@@ -29,6 +31,7 @@ module.exports = function (givenOptions, callbacky) {
         require('search-index-searcher')(SearchIndex.options, callback)
       }     
     ], function(err, results){
+      if (err) return callbacky(err)
       
       const searchIndexAdder = results[0]
       const searchIndexGetter = results[1]


### PR DESCRIPTION
I discovered that these errors weren't handled when I tried to create an index in directory whose parent did not exist. Rather than show a meaningful error, I got an error about indexAdder not having an add property. This PR bubbles errors and resolves the situation I experienced.