### PR TITLE
Makes example 3 tackle "key": null

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -98,8 +98,10 @@ const printResults = function (data) {
     return item.substring(2)
   })  
   for (var key in data.document) {
-    var teaser = tc(data.document[key], terms)
-    if (teaser) console.log(teaser)
+    if (data.document[key]) {
+      var teaser = tc(data.document[key], terms)
+      if (teaser) console.log(teaser)
+    }
   }
   console.log()
 }


### PR DESCRIPTION
Not sure if it's 100% correct what I do, but I made a JSON stream with null in it work. Or else the term-cluster (I think it was) will make it crash. Test-data: https://raw.githubusercontent.com/eklem/dataset-vinmonopolet/master/dataset-vinmonopolet-sparkling.str