### PR TITLE
Some small query object errors in the documentation?

### DIFF
--- a/doc/search.md
+++ b/doc/search.md
@@ -42,7 +42,7 @@ results. In the example below, only documents containing the word *reagan*
 in the `title` field **AND** the word *usa* in the `body` field will be returned.
 
 ```javascript
-q.query = 
+q.query = {
   {
     AND: {
       'title': ['reagan'],
@@ -76,7 +76,7 @@ q.query = [                   // Each array element is an OR condition
       'body':  ['usa']        // NOT 'usa' in the body field
     }
   }
-}
+]
 ```
 
 


### PR DESCRIPTION
Seems fielded search and boolean search has some bugs. Is it correct now? Can q.query both be an array of objects and an object?