### PR TITLE
Improved separator regex from options

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -31,7 +31,7 @@ The default options are equivalent to this:
   logLevel: 'error',
   nGramLength: 1,
   nGramSeparator: ' ',
-  separator: /[\|' \.,\-|(\n)]+/,
+  separator: /[' .,\-|(\n)]+/,
   stopwords: require('stopword').en,
 }
 ```


### PR DESCRIPTION
 /[\|' \.,\-|(\n)]+/     --->    /[' .,\-|(\n)]+/