### PR TITLE
switching from si-2 to si library

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fergiemcdowall/search-index-2.git"
+    "url": "git+https://github.com/fergiemcdowall/search-index.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/fergiemcdowall/search-index-2/issues"
+    "url": "https://github.com/fergiemcdowall/search-index/issues"
   },
-  "homepage": "https://github.com/fergiemcdowall/search-index-2#readme",
+  "homepage": "https://github.com/fergiemcdowall/search-index#readme",
   "devDependencies": {
     "level-out": "^1.0.0",
     "standard": "^12.0.1",


### PR DESCRIPTION
package.json was referencing to work-library