### PR TITLE
search-index@0.15.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 const Logger = require('js-logger')
 const level = require('levelup')
-const down = require('leveldown')
 const SearchIndexAdder = require('search-index-adder')
 const SearchIndexSearcher = require('search-index-searcher')
 
@@ -75,6 +74,7 @@ const getOptions = function (options, done) {
   // Use the global one because the library doesn't support providing handler to named logger
   Logger.setHandler(SearchIndex.options.logHandler)
   if (!options.indexes) {
+    const down = require('leveldown')
     level(SearchIndex.options.indexPath || 'si', {
       valueEncoding: 'json',
       db: down


### PR DESCRIPTION
Hi there,

I'm using search-index@0.15.1 with `levelup` and `redis` as a db.
I'm **not** using `leveldown`/`levelDB` so I don't want to install it (plus, it doesn't build on the specific node-alpine version I am targeting), that's why I am installing `search-index` with the `--no-optional` option.

The problem is, despite `leveldown`  being marked as optional, it's required at the top of the search-index/index.js, so when I start my app it immediately crashes, complaining about `leveldown` not being resolvable.

The fix is easy: move the require down, so that it's only executed when necessary.

**/!\ This shouldn't be merged to master**

As I am using an older version of search-index (and I can't easily upgrade) this should be merged in a separate release branch. I saw you have tags for versions, but no release branches.
Could you create a release branche for version 0.15? It can done that way:

```bash
git checkout v0.15.1 # checkout the tag, in a detached state
git checkout -b release/0.15
```

Then push this fix as v0.15.2?

Cheers