### PR TITLE
Fix auto-generated IDs not always being unique.

### DIFF
--- a/src/write.js
+++ b/src/write.js
@@ -69,14 +69,16 @@ module.exports = (fii, ops) => {
     ? ({ body: doc })
     : doc
 
-  // TODO: generated IDs are derived from timestamps. Possibly there
-  // should be some sort of timer here that makes sure that this
-  // function uses at least 1 millisecond in order to avoid id collisions
+  let counter = 0;
   const generateId = (doc, i) => (typeof doc._id === 'undefined')
     ? Object.assign(doc, {
-        _id: Date.now() + '-' + i
-      })
-    : doc
+      // counter is needed because if this function is called in quick
+      // succession, Date.now() is not guaranteed to be unique. This could
+      // still conflict if the DB is closed, clock is reset to the past, then
+      // DB reopened. That's a bit of a corner case though.
+      _id: `${Date.now()}-${i}-${counter++}`,
+    })
+    : doc;
 
   const indexingPipeline = docs => new Promise(
     resolve => resolve(


### PR DESCRIPTION
Due to timer coalescing and other optimizations in OSes and JavaScript engines, Date.now() can return the same value over several milliseconds. This means that if you call PUT() more than 100 times a second or so, you're likely to generate the same ID and accidentally overwrite recently-inserted data.

This change fixes the issue. Overwriting is still possible, but you'd have to close the DB, change the system's clock to an earlier time, then reopen the DB and start inserting data.
